### PR TITLE
Added dmidecode to the packages to be installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir -p /run/lock/subsys
 # Do overall update and install missing packages needed for OpenManage
 RUN yum -y update && \
     yum -y install gcc wget perl passwd which tar libstdc++.so.6 compat-libstdc++-33.i686 glibc.i686 \
-        net-snmp net-snmp-sysvinit nano
+        net-snmp net-snmp-sysvinit nano dmidecode
 
 COPY resources/snmpd.conf /etc/snmp/snmpd.conf
 RUN /etc/init.d/snmpd start


### PR DESCRIPTION
Added dmidecode because missing it on CentOS 7 causes the dsu-Scripts to give the following warning/error:

`Fetching SAS-Drive_Firmware_XJ1HM_LN32_FS66_A08 ...
Installing SAS-Drive_Firmware_XJ1HM_LN32_FS66_A08 ...
Collecting inventory...
sh: dmidecode: command not found
sh: dmidecode: command not found`