### PR TITLE
Modified Dockerfile and entrypoint.sh to allow customized commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,9 +62,7 @@ COPY ./resources/entrypoint.sh /fake-systemd-entrypoint.sh
 
 COPY resources/snmpd.conf /etc/snmp/snmpd.conf
 
-ENTRYPOINT ["/fake-systemd-entrypoint.sh"]
-CMD ["tail", "-f", "/opt/dell/srvadmin/var/log/openmanage/*.xml"]
-
 WORKDIR /opt/dell/srvadmin/bin
 
 EXPOSE 1311 161 162
+ENTRYPOINT ["/fake-systemd-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This image has been tested on the following Dell hardware:
 
 | Hardware            | Status       |
 |---------------------|--------------|
+| Dell PowerEdge R510 | OK |
 | Dell PowerEdge R610 | OK |
 | Dell PowerEdge R620 | OK |
 | Dell PowerEdge R710 | OK |

--- a/resources/entrypoint.sh
+++ b/resources/entrypoint.sh
@@ -28,3 +28,4 @@ if [ "$#" -gt 0 ]; then
     # Use eval instead of exec so this script remains PID 1
     eval "$@"
 fi
+tail -f /opt/dell/srvadmin/var/log/openmanage/*.xml


### PR DESCRIPTION
Hi Kamermans,

I tried to change root password by adding "echo 'root:xxx'|chpasswd" at the end of docker run command but the image runs less than 1min then quits. Not sure why it didn't evoke the tail -f command. So I made this change. Please feel free merge or ignore.